### PR TITLE
Add Options For File Saving

### DIFF
--- a/ass.js
+++ b/ass.js
@@ -7,7 +7,7 @@ try {
 }
 
 // Load the config
-const { host, port, domain, useSsl, resourceIdSize, resourceIdType, isProxied } = require('./config.json');
+const { host, port, domain, useSsl, resourceIdSize, resourceIdType, isProxied, diskFilePath, saveWithDate, saveAsOriginal } = require('./config.json');
 
 //#region Imports
 const fs = require('fs-extra');
@@ -19,7 +19,25 @@ const { path, saveData, log, verify, generateToken, generateId } = require('./ut
 
 //#region Variables, module setup
 const app = express();
-const upload = multer({ dest: 'uploads/' });
+// Configure filename and location settings
+const storage = multer.diskStorage({
+	destination: saveWithDate ? (req, file, cb) => {
+		// Get current month and year
+		const [month, day, year] = new Date().toLocaleDateString("en-US").split("/")
+
+		// Add 0 before single digit months eg ( 6 turns into 06)
+		const folder = `${diskFilePath}/${year}-${("0" + month).slice(-2)}`
+
+		// Create folder if it doesn't exist
+		fs.ensureDirSync(folder)
+
+		cb(null, folder)
+	} : diskFilePath,
+
+	filename: saveAsOriginal ? (req, file, cb) => cb(null, file.originalname) : null,
+})
+   
+var upload = multer({ storage: storage })
 var tokens = [];
 var data = {};
 //#endregion

--- a/setup.js
+++ b/setup.js
@@ -15,7 +15,10 @@ const config = {
 	useSsl: true,
 	isProxied: true,
 	resourceIdSize: 12,
-	resourceIdType: 'zws'
+	resourceIdType: 'zws',
+	saveWithDate: false,
+	diskFilePath: "uploads/",
+	saveAsOriginal: true,
 };
 
 // Schema for setup prompts
@@ -64,7 +67,25 @@ const setupSchema = {
 			require: false,
 			pattern: /(original|zws|random)/gi,
 			message: 'Must be one of: original, zws, random'
-		}
+		},
+		saveWithDate: {
+			description: 'Do you want to use date folder structure? Eg (uploads/2021-04/image.png)',
+			type: 'boolean',
+			default: config.saveWithDate,
+			required: false
+		},
+		diskFilePath: {
+			description: 'Where on the disk do you want to save?',
+			type: 'string',
+			default: config.diskFilePath,
+			required: false
+		},
+		saveAsOriginal: {
+			description: 'Save as original file name? (Use file name instead of randomly generated characters)',
+			type: 'boolean',
+			default: config.saveAsOriginal,
+			required: false
+		},
 	}
 };
 


### PR DESCRIPTION
Added 3 new options configuring how files should be saved on the disk. Also added to setup script.

1. Date Folder Structure
Save images within current Year and Month folder (used same default as ShareX with year-month formatting)

2. Customise File Destination
Change the location of uploads from "uploads/" to anything.
Perhaps an additional feature could be error checking to ensure it's a valid path?

3. Save As Original File Name
Currently files get saved with randomly generated file name and no file extension. Adds option to save with same name and file extension as uploaded.

Feel free to change the descriptions in the setup script, I tried my best to describe setting but there's room for improvement.

Thanks for the software, let me know if you have any questions.