### PR TITLE
Fix Flameshot bug

### DIFF
--- a/flameshot_example.sh
+++ b/flameshot_example.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+RAND=$RANDOM$RANDOM #Random number, because ass displays the same file with different URLs depending on its original name while using ZWS mode
 IMAGEPATH="$HOME/Pictures/" #where to hold the screenshots before they are deleted
-IMAGENAME="ass" #Not really important, tells flameshot what file to send and delete
+IMAGENAME="$RAND" #Not really important unless using ZWS (see $RAND.) tells flameshot what file to send and delete
 KEY="" #Enter auth key
 DOMAIN="" #your upload domain
 


### PR DESCRIPTION
While using 'ZWS' Content mode, if 2 files original (at upload) names matches, discord will display the first image twice, instead of each image. by making the upload names random, it severely reduces the chance of this happening.