### PR TITLE
Fixed some `docker-compose exec` missing the container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Easy! Just pull the changes & run this one-liner:
 git pull
 
 # Rebuild the container with the new changes (uncomment the 2nd part if the update requires refreshing the config)
-docker-compose up --force-recreate --build -d && docker image prune -f # docker-compose exec npm run setup && docker-compose restart
+docker-compose up --force-recreate --build -d && docker image prune -f # docker-compose exec ass npm run setup && docker-compose restart
 ```
 
 - `--force-recreate` will force the container to rebuild
@@ -398,7 +398,7 @@ ass has a number of pre-made npm scripts for you to use. **All** of these script
 | `logs` | Uses the [tlog Socket plugin] to stream logs from the ass server to your terminal, with full colour support (Remember to set [`FORCE_COLOR`] if you're using Systemd) |
 | `docker-logs` | Alias for `docker-compose logs -f --tail=50 --no-log-prefix ass` |
 | `docker-update` | Alias for `git pull && docker-compose up --force-recreate --build -d && docker image prune -f` |
-| `docker-resetup` | Alias for `docker-compose exec npm run setup && docker-compose restart` |
+| `docker-resetup` | Alias for `docker-compose exec ass npm run setup && docker-compose restart` |
 
 [tlog Socket plugin]: https://github.com/tycrek/tlog#socket
 [`FORCE_COLOR`]: https://nodejs.org/dist/latest-v14.x/docs/api/cli.html#cli_force_color_1_2_3

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "logs": "node ./node_modules/@tycrek/log/socketClient.js",
     "docker-logs": "docker-compose logs -f --tail=50 --no-log-prefix ass",
     "docker-update": "git pull && docker-compose up --force-recreate --build -d && docker image prune -f",
-    "docker-resetup": "docker-compose exec npm run setup && docker-compose restart"
+    "docker-resetup": "docker-compose exec ass npm run setup && docker-compose restart"
   },
   "repository": "github:tycrek/ass",
   "keywords": [


### PR DESCRIPTION
## Checklist
<!-- All boxes are required -->

- [x] I have read the [Contributing Guidelines]
- [x] I acknowledge that any submitted code will be licensed under the [ISC License]
- [x] I confirm that submitted code is my own work
- [x] I have tested the code, and confirm that it works

## Enviroment
<!-- Describe your development environment -->

- Operating System: Ubuntu 20.04
- Node version: 14
- NPM version: 7

## Description
<!-- Describe your PR in detail. Include links to any relevant Issues. -->

Some instances of `docker-compose exec` were missing the container name `ass`.

[Contributing Guidelines]: https://github.com/tycrek/ass/blob/master/CONTRIBUTING.md
[ISC License]: https://github.com/tycrek/ass/blob/master/LICENSE
