### PR TITLE
Switched to `discord-webhook-node`, dropping `discord.js` for webhooks (closes #74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,20 +261,11 @@ You can insert certain metadata into your embeds with these placeholders:
 
 ### Webhooks
 
-You may use Discord webhooks as an easy way to keep track of your uploads. The first step is to [create a new Webhook]. You only need to follow the first section, **Making a Webhook**. Once you are done that, click **Copy Webhook URL**. Next, paste your URL into a text editor. Extract these two values from the URL:
-
-```
-https://discord.com/api/webhooks/12345678910/T0kEn0fw3Bh00K
-                                 ^^^^^^^^^^  ^^^^^^^^^^^^ 
-                                 Webhook ID  Webhook Token
-```
-
-Once you have these, add the following HTTP headers to your ShareX config:
+You may use Discord webhooks as an easy way to keep track of your uploads. The first step is to [create a new Webhook]. You only need to follow the first section, **Making a Webhook**. Once you are done that, click **Copy Webhook URL**. Finally, add these headers to your custom uploader:
 
 | Header | Purpose |
 | ------ | ------- |
-| **`X-Ass-Webhook-Client`** | The **Webhook ID** |
-| **`X-Ass-Webhook-Token`** | The **Webhook Token** |
+| **`X-Ass-Webhook-Url`** | The **Webhook URL** you copied |
 | **`X-Ass-Webhook-Username`** | (Optional) the "username" of the Webhook; can be set to whatever you want |
 | **`X-Ass-Webhook-Avatar`** | (Optional) URL to an image to use as the Webhook avatar. Use the **full** URL including `https://` |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "aws-sdk": "^2.930.0",
         "check-node-version": "^4.1.0",
         "crypto-random-string": "3.3.1",
-        "discord.js": "^12.5.3",
+        "discord-webhook-node": "^1.1.8",
         "escape-html": "^1.0.3",
         "express": "^4.17.1",
         "express-rate-limit": "^5.2.6",
@@ -100,24 +100,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@discordjs/collection": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
-      "integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ=="
-    },
-    "node_modules/@discordjs/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-ZfFsbgEXW71Rw/6EtBdrP5VxBJy4dthyC0tpQKGKmYFImlmmrykO14Za+BiIVduwjte0jXEBlhSKf0MWbFp9Eg==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@jimp/bmp": {
@@ -726,17 +708,6 @@
       "integrity": "sha512-mtSlBdHkFNr4FOnMtqtHJxy9z5AsUcZzGlpiHzvWOoaoN9lNTDPwxOBd0q4VTYWuGPrIm6Fuq5m7aRbLv7KqiQ==",
       "dependencies": {
         "@vibrant/types": "^3.2.1-alpha.1"
-      }
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
       }
     },
     "node_modules/accepts": {
@@ -1522,23 +1493,13 @@
         "node": ">=4.5.0"
       }
     },
-    "node_modules/discord.js": {
-      "version": "12.5.3",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.5.3.tgz",
-      "integrity": "sha512-D3nkOa/pCkNyn6jLZnAiJApw2N9XrIsXUAdThf01i7yrEuqUmDGc7/CexVWwEcgbQR97XQ+mcnqJpmJ/92B4Aw==",
-      "deprecated": "no longer supported",
+    "node_modules/discord-webhook-node": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/discord-webhook-node/-/discord-webhook-node-1.1.8.tgz",
+      "integrity": "sha512-3u0rrwywwYGc6HrgYirN/9gkBYqmdpvReyQjapoXARAHi0P0fIyf3W5tS5i3U3cc7e44E+e7dIHYUeec7yWaug==",
       "dependencies": {
-        "@discordjs/collection": "^0.1.6",
-        "@discordjs/form-data": "^3.0.1",
-        "abort-controller": "^3.0.0",
-        "node-fetch": "^2.6.1",
-        "prism-media": "^1.2.9",
-        "setimmediate": "^1.0.5",
-        "tweetnacl": "^1.0.3",
-        "ws": "^7.4.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
+        "form-data": "^3.0.0",
+        "node-fetch": "^2.6.0"
       }
     },
     "node_modules/doctypes": {
@@ -1609,14 +1570,6 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/events": {
@@ -1759,6 +1712,19 @@
       "integrity": "sha1-x7vxJN7ELJ0ZHPuUfQqXeN2YbAw=",
       "dependencies": {
         "imul": "^1.0.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -2635,31 +2601,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/prism-media": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.2.tgz",
-      "integrity": "sha512-L6UsGHcT6i4wrQhFF1aPK+MNYgjRqR2tUoIqEY+CG1NqVkMjPRKzS37j9f8GiYPlD6wG9ruBj+q5Ax+bH8Ik1g==",
-      "peerDependencies": {
-        "@discordjs/opus": "^0.5.0",
-        "ffmpeg-static": "^4.2.7 || ^3.0.0 || ^2.4.0",
-        "node-opus": "^0.3.3",
-        "opusscript": "^0.0.8"
-      },
-      "peerDependenciesMeta": {
-        "@discordjs/opus": {
-          "optional": true
-        },
-        "ffmpeg-static": {
-          "optional": true
-        },
-        "node-opus": {
-          "optional": true
-        },
-        "opusscript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -3077,11 +3018,6 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
     "node_modules/setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
@@ -3319,11 +3255,6 @@
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/type-fest": {
       "version": "0.8.1",
@@ -3567,26 +3498,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
-    "node_modules/ws": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/xhr": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
@@ -3738,21 +3649,6 @@
         "concat-stream": "^1.6.2",
         "http-response-object": "^3.0.1",
         "parse-cache-control": "^1.0.1"
-      }
-    },
-    "@discordjs/collection": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
-      "integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ=="
-    },
-    "@discordjs/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-ZfFsbgEXW71Rw/6EtBdrP5VxBJy4dthyC0tpQKGKmYFImlmmrykO14Za+BiIVduwjte0jXEBlhSKf0MWbFp9Eg==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
       }
     },
     "@jimp/bmp": {
@@ -4228,14 +4124,6 @@
       "integrity": "sha512-mtSlBdHkFNr4FOnMtqtHJxy9z5AsUcZzGlpiHzvWOoaoN9lNTDPwxOBd0q4VTYWuGPrIm6Fuq5m7aRbLv7KqiQ==",
       "requires": {
         "@vibrant/types": "^3.2.1-alpha.1"
-      }
-    },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "requires": {
-        "event-target-shim": "^5.0.0"
       }
     },
     "accepts": {
@@ -4835,19 +4723,13 @@
         "streamsearch": "0.1.2"
       }
     },
-    "discord.js": {
-      "version": "12.5.3",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.5.3.tgz",
-      "integrity": "sha512-D3nkOa/pCkNyn6jLZnAiJApw2N9XrIsXUAdThf01i7yrEuqUmDGc7/CexVWwEcgbQR97XQ+mcnqJpmJ/92B4Aw==",
+    "discord-webhook-node": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/discord-webhook-node/-/discord-webhook-node-1.1.8.tgz",
+      "integrity": "sha512-3u0rrwywwYGc6HrgYirN/9gkBYqmdpvReyQjapoXARAHi0P0fIyf3W5tS5i3U3cc7e44E+e7dIHYUeec7yWaug==",
       "requires": {
-        "@discordjs/collection": "^0.1.6",
-        "@discordjs/form-data": "^3.0.1",
-        "abort-controller": "^3.0.0",
-        "node-fetch": "^2.6.1",
-        "prism-media": "^1.2.9",
-        "setimmediate": "^1.0.5",
-        "tweetnacl": "^1.0.3",
-        "ws": "^7.4.4"
+        "form-data": "^3.0.0",
+        "node-fetch": "^2.6.0"
       }
     },
     "doctypes": {
@@ -4907,11 +4789,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-    },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "events": {
       "version": "1.1.1",
@@ -5028,6 +4905,16 @@
       "integrity": "sha1-x7vxJN7ELJ0ZHPuUfQqXeN2YbAw=",
       "requires": {
         "imul": "^1.0.0"
+      }
+    },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -5714,12 +5601,6 @@
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
       "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
     },
-    "prism-media": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.2.tgz",
-      "integrity": "sha512-L6UsGHcT6i4wrQhFF1aPK+MNYgjRqR2tUoIqEY+CG1NqVkMjPRKzS37j9f8GiYPlD6wG9ruBj+q5Ax+bH8Ik1g==",
-      "requires": {}
-    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -6065,11 +5946,6 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
@@ -6249,11 +6125,6 @@
       "requires": {
         "utf8-byte-length": "^1.0.1"
       }
-    },
-    "tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "type-fest": {
       "version": "0.8.1",
@@ -6442,12 +6313,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "ws": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-      "requires": {}
     },
     "xhr": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "aws-sdk": "^2.930.0",
     "check-node-version": "^4.1.0",
     "crypto-random-string": "3.3.1",
-    "discord.js": "^12.5.3",
+    "discord-webhook-node": "^1.1.8",
     "escape-html": "^1.0.3",
     "express": "^4.17.1",
     "express-rate-limit": "^5.2.6",


### PR DESCRIPTION
## Checklist
<!-- All boxes are required -->

- [x] I have read the [Contributing Guidelines]
- [x] I acknowledge that any submitted code will be licensed under the [ISC License]
- [x] I confirm that submitted code is my own work
- [x] I have tested the code, and confirm that it works

## Enviroment
<!-- Describe your development environment -->

- Operating System: Windows 10
- Node version: Node 14
- NPM version: NPM 7

## Description
<!-- Describe your PR in detail. Include links to any relevant Issues. -->

Discord.js is a pretty huge lib being used for a pretty tiny feature. This PR switches to [discord-webhook-node] which is much more lightweight and also resolves some odd issues for some hosts.

Users will need to update their webhook headers in this update for webhooks to continue to work. Hosts are expected to tell their users of this change when updating.

This PR closes Issue #74.

[Contributing Guidelines]: https://github.com/tycrek/ass/blob/master/CONTRIBUTING.md
[ISC License]: https://github.com/tycrek/ass/blob/master/LICENSE

[discord-webhook-node]: https://www.npmjs.com/package/discord-webhook-node