### PR TITLE
Fixed incorrect path check for custom index (cherry picked from ts branch)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -194,11 +194,11 @@ For HTTPS support, you must configure a reverse proxy. I recommend Caddy but any
 [Caddy]: https://caddyserver.com/
 [my tutorial]: https://jmoore.dev/tutorials/2021/03/caddy-express-reverse-proxy/
 
-### Generating new tokens
+## Generating new tokens
 
 If you need to generate a new token at any time, run `npm run new-token <username>`. This will **automatically** load the new token so there is no need to restart ass. Username field is optional; if left blank, a random username will be created.
 
-### Cloudflare users
+## Cloudflare users
 
 In your Cloudflare DNS dashboard, set your domain/subdomain to **DNS Only** if you experience issues with **Proxied**.
 
@@ -280,7 +280,7 @@ By default, ass directs the index route `/` to this README. Follow these steps t
 1. Run `npm run setup` to re-run the setup script.
    - The defaults are set by your existing config, so you can press `Enter` to accept the defaults on most prompts.
    - The one setting you want to change is `Filename for your custom index`. Enter a name for your index, including `.js` (custom index's must be `.js` files).
-2. Make a new file matching the name you entered.
+2. Make a new file in the `share/` directory matching the name you entered (this directory can be found in the `ass/` directory. It is created automatically after setup is run).
 3. Your index file needs to export a single function taking three arguments: `(req, res, next)`. Some code samples for common use cases are provided below.
 4. Restart ass. The startup info logs should say **`Custom index:`**` enabled`.
 

--- a/ass.js
+++ b/ass.js
@@ -66,7 +66,7 @@ useSsl && app.use(helmet.hsts({ preload: true })); // skipcq: JS-0093
 app.use(nofavicon);
 
 // Use custom index, otherwise render README.md
-const ASS_INDEX = indexFile !== '' && fs.existsSync(`./${indexFile}`) && require(`./${indexFile}`);
+const ASS_INDEX = indexFile !== '' && fs.existsSync(path(`${indexFile}`)) && require(`./${indexFile}`);
 const ASS_INDEX_ENABLED = typeof ASS_INDEX === typeof Function;
 app.get('/', (req, res, next) => ASS_INDEX_ENABLED // skipcq: JS-0229
 	? ASS_INDEX(req, res, next)

--- a/ass.js
+++ b/ass.js
@@ -66,7 +66,7 @@ useSsl && app.use(helmet.hsts({ preload: true })); // skipcq: JS-0093
 app.use(nofavicon);
 
 // Use custom index, otherwise render README.md
-const ASS_INDEX = indexFile !== '' && fs.existsSync(path(`${indexFile}`)) && require(`./${indexFile}`);
+const ASS_INDEX = indexFile !== '' && fs.existsSync(path('share', indexFile)) && require(`./share/${indexFile}`);
 const ASS_INDEX_ENABLED = typeof ASS_INDEX === typeof Function;
 app.get('/', (req, res, next) => ASS_INDEX_ENABLED // skipcq: JS-0229
 	? ASS_INDEX(req, res, next)


### PR DESCRIPTION
## Checklist
<!-- All boxes are required -->

- [x] I have read the [Contributing Guidelines]
- [x] I acknowledge that any submitted code will be licensed under the [ISC License]
- [x] I confirm that submitted code is my own work
- [x] I have tested the code, and confirm that it works

## Enviroment
<!-- Describe your development environment -->

- Operating System: Windows 10
- Node version: Node 14
- NPM version: NPM 7

## Description
<!-- Describe your PR in detail. Include links to any relevant Issues. -->

Custom index is now loaded out of the `share/` directory. Also cherry picked improved path loading from https://github.com/tycrek/ass/commit/f201792193536ad7a06d3b2f62da9bab94ec1597

[Contributing Guidelines]: https://github.com/tycrek/ass/blob/master/CONTRIBUTING.md
[ISC License]: https://github.com/tycrek/ass/blob/master/LICENSE
