### PR TITLE
🕛 added a header for setting the time offset (closes #63)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -234,6 +234,7 @@ If you need to override a specific part of the config to be different from the g
 | **`X-Ass-Domain`** | Override the domain returned for the clipboard (useful for multi-domain hosts) |
 | **`X-Ass-Access`** | Override the generator used for the resource URL. Must be one of: `original`, `zws`, `gfycat`, or `random` ([see above](#access-types)) |
 | **`X-Ass-Gfycat`** | Override the length of Gfycat ID's. Defaults to `2` |
+| **`X-Ass-Timeoffset`** | Override the timestamp offset. Defaults to `UTC+0` |
 
 ### Fancy embeds
 

--- a/routers/resource.js
+++ b/routers/resource.js
@@ -39,7 +39,7 @@ router.get('/', (req, res, next) => data.get(req.ass.resourceId).then((fileData)
 		title: escape(fileData.originalname),
 		mimetype: fileData.mimetype,
 		uploader: users[fileData.token].username,
-		timestamp: formatTimestamp(fileData.timestamp),
+		timestamp: formatTimestamp(fileData.timestamp, fileData.timeoffset),
 		size: formatBytes(fileData.size),
 		color: getResourceColor(fileData.opengraph.color || null, fileData.vibrant),
 		resourceAttr: { src: getDirectUrl(resourceId) },
@@ -47,7 +47,7 @@ router.get('/', (req, res, next) => data.get(req.ass.resourceId).then((fileData)
 		oembedUrl: `${getTrueHttp()}${getTrueDomain()}/${resourceId}/oembed`,
 		ogtype: fileData.is.video ? 'video.other' : fileData.is.image ? 'image' : 'website',
 		urlType: `og:${fileData.is.video ? 'video' : fileData.is.audio ? 'audio' : 'image'}`,
-		opengraph: replaceholder(ogs.join('\n'), fileData.size, fileData.timestamp, fileData.originalname),
+		opengraph: replaceholder(ogs.join('\n'), fileData.size, fileData.timestamp, fileData.timeoffset, fileData.originalname),
 		viewDirect
 	});
 }).catch(next));
@@ -85,14 +85,14 @@ router.get('/thumbnail', (req, res, next) =>
 // https://old.reddit.com/r/discordapp/comments/82p8i6/a_basic_tutorial_on_how_to_get_the_most_out_of/
 router.get('/oembed', (req, res, next) =>
 	data.get(req.ass.resourceId)
-		.then(({ opengraph, is, size, timestamp, originalname }) =>
+		.then(({ opengraph, is, size, timestamp, timeoffset, originalname }) => 
 			res.type('json').send({
 				version: '1.0',
 				type: is.video ? 'video' : is.image ? 'photo' : 'link',
 				author_url: opengraph.authorUrl,
 				provider_url: opengraph.providerUrl,
-				author_name: replaceholder(opengraph.author || '', size, timestamp, originalname),
-				provider_name: replaceholder(opengraph.provider || '', size, timestamp, originalname)
+				author_name: replaceholder(opengraph.author || '', size, timestamp, timeoffset, originalname),
+				provider_name: replaceholder(opengraph.provider || '', size, timestamp, timeoffset, originalname)
 			}))
 		.catch(next));
 

--- a/routers/upload.js
+++ b/routers/upload.js
@@ -48,7 +48,7 @@ router.post('/', (req, res, next) => {
 	req.file.timestamp = DateTime.now().toMillis();
 
 	// Save the timezone offset
-	req.file.timeoffset = req.headers['x-ass-timeoffset'] || "UTC+0";
+	req.file.timeoffset = req.headers['x-ass-timeoffset'] || 'UTC+0';
 
 	// Keep track of the token that uploaded the resource
 	req.file.token = req.token;

--- a/routers/upload.js
+++ b/routers/upload.js
@@ -47,6 +47,9 @@ router.post('/', (req, res, next) => {
 	// Get the uploaded time in milliseconds
 	req.file.timestamp = DateTime.now().toMillis();
 
+	// Save the timezone offset
+	req.file.timeoffset = req.headers['x-ass-timeoffset'] || "UTC+0";
+
 	// Keep track of the token that uploaded the resource
 	req.file.token = req.token;
 

--- a/utils.js
+++ b/utils.js
@@ -45,8 +45,8 @@ function getResourceColor(colorValue, vibrantValue) {
 	return colorValue === '&random' ? randomHexColour() : colorValue === '&vibrant' ? vibrantValue : colorValue;
 }
 
-function formatTimestamp(timestamp) {
-	return DateTime.fromMillis(timestamp).toLocaleString(DateTime.DATETIME_MED);
+function formatTimestamp(timestamp, timeoffset) {
+	return DateTime.fromMillis(timestamp).setZone(timeoffset).toLocaleString(DateTime.DATETIME_MED);
 }
 
 function formatBytes(bytes, decimals = 2) { // skipcq: JS-0074
@@ -56,11 +56,11 @@ function formatBytes(bytes, decimals = 2) { // skipcq: JS-0074
 	return parseFloat((bytes / Math.pow(KILOBYTES, i)).toFixed(decimals < 0 ? 0 : decimals)).toString().concat(` ${sizes[i]}`);
 }
 
-function replaceholder(data, size, timestamp, originalname) {
+function replaceholder(data, size, timestamp, timeoffset, originalname) {
 	return data
 		.replace(/&size/g, formatBytes(size))
 		.replace(/&filename/g, originalname)
-		.replace(/&timestamp/g, formatTimestamp(timestamp));
+		.replace(/&timestamp/g, formatTimestamp(timestamp, timeoffset));
 }
 
 function getDatedDirname() {


### PR DESCRIPTION
## Checklist
<!-- All boxes are required -->

- [x] I have read the [Contributing Guidelines]
- [x] I acknowledge that any submitted code will be licensed under the [ISC License]
- [x] I confirm that submitted code is my own work
- [x] I have tested the code, and confirm that it works

## Enviroment
<!-- Describe your development environment -->

- Operating System: Linux (Node 14.17.3 image from the Dockerfile)
- Node version:  14.17.3
- NPM version: 7.24.2

## Description
<!-- Describe your PR in detail. Include links to any relevant Issues. -->
I've added a header called `X-Ass-Timeoffset` so you can change the UTC offset to something like `UTC+1`.
The fallback value is `UTC+0`, so if you don't set it to anything else it will work as it did before.
This probably is linked with this feature issue #63 


[Contributing Guidelines]: https://github.com/tycrek/ass/blob/master/CONTRIBUTING.md
[ISC License]: https://github.com/tycrek/ass/blob/master/LICENSE
