### PR TITLE
better error handling for rm and curl

### DIFF
--- a/flameshot_example.sh
+++ b/flameshot_example.sh
@@ -7,19 +7,18 @@ DOMAIN="" # Your upload domain (without http:// or https://)
 flameshot config -f "$IMAGENAME" # Make sure that Flameshot names the file correctly
 flameshot gui -r -p "$IMAGEPATH" # Prompt the screenshot GUI
 
-FILE=$FILE/$IMAGENAME # Fİle path and file name combined
+FILE="$IMAGEPATH$IMAGENAME.png" # File path and file name combined
 
-if test -f "$FILE/$IMAGENAME"; then # Check if file exists to handle Curl and rm errors
+# Check if file exists to handle Curl and rm errors
+if test -f "$FILE"; then
+  # Then upload the image and copy the response URL
+  URL=$(curl -X POST \
+    -H "Content-Type: multipart/form-data" \
+    -H "Accept: application/json" \
+    -H "User-Agent: ShareX/13.4.0" \
+    -H "Authorization: $KEY" \
+    -F "file=@$FILE" "https://$DOMAIN/" | grep -Po '(?<="resource":")[^"]+')
 
-# Upload the image and copy the response URL
-    URL=$(curl -X POST \
-      -H "Content-Type: multipart/form-data" \
-      -H "Accept: application/json" \
-      -H "User-Agent: ShareX/13.4.0" \
-      -H "Authorization: $KEY" \
-      -F "file=@$IMAGEPATH$IMAGENAME.png" "https://$DOMAIN/" | grep -Po '(?<="resource":")[^"]+')
-    rm "$FILE"
-fi
-# Echo instead of printf as echo is marginally faster than printf
-echo -e "$URL" | xclip -sel clip
-
+  echo -n "$URL" | xclip -sel clip # Uses echo instead of printf as echo is marginally faster than printf
+  rm "$FILE"
+fi 

--- a/flameshot_example.sh
+++ b/flameshot_example.sh
@@ -21,5 +21,5 @@ if test -f "$FILE/$IMAGENAME"; then # Check if file exists to handle Curl and rm
     rm $FILE
 fi
 # Echo instead of printf as echo is marginally faster than printf
-echo -n "$URL" | xclip -sel clip
+echo -e "$URL" | xclip -sel clip
 

--- a/flameshot_example.sh
+++ b/flameshot_example.sh
@@ -19,6 +19,6 @@ if test -f "$FILE"; then
     -H "Authorization: $KEY" \
     -F "file=@$FILE" "https://$DOMAIN/" | grep -Po '(?<="resource":")[^"]+')
 
-  echo -n "$URL" | xclip -sel clip # Uses echo instead of printf as echo is marginally faster than printf
+  printf "%s" "$URL" | xclip -sel clip # Uses echo instead of printf as echo is marginally faster than printf
   rm "$FILE"
 fi 

--- a/flameshot_example.sh
+++ b/flameshot_example.sh
@@ -18,7 +18,7 @@ if test -f "$FILE/$IMAGENAME"; then # Check if file exists to handle Curl and rm
       -H "User-Agent: ShareX/13.4.0" \
       -H "Authorization: $KEY" \
       -F "file=@$IMAGEPATH$IMAGENAME.png" "https://$DOMAIN/" | grep -Po '(?<="resource":")[^"]+')
-    rm $FILE
+    rm "$FILE"
 fi
 # Echo instead of printf as echo is marginally faster than printf
 echo -e "$URL" | xclip -sel clip

--- a/flameshot_example.sh
+++ b/flameshot_example.sh
@@ -7,14 +7,19 @@ DOMAIN="" # Your upload domain (without http:// or https://)
 flameshot config -f "$IMAGENAME" # Make sure that Flameshot names the file correctly
 flameshot gui -r -p "$IMAGEPATH" # Prompt the screenshot GUI
 
-# Upload the image and copy the response URL
-URL=$(curl -X POST \
-  -H "Content-Type: multipart/form-data" \
-  -H "Accept: application/json" \
-  -H "User-Agent: ShareX/13.4.0" \
-  -H "Authorization: $KEY" \
-  -F "file=@$IMAGEPATH$IMAGENAME.png" "https://$DOMAIN/" | grep -Po '(?<="resource":")[^"]+')
-# printf instead of echo as echo appends a newline
-printf "%s" "$URL" | xclip -sel clip
+FILE=$FILE/$IMAGENAME # Fİle path and file name combined
 
-rm "$IMAGEPATH$IMAGENAME.png" # Delete the image locally
+if test -f "$FILE/$IMAGENAME"; then # Check if file exists to handle Curl and rm errors
+
+# Upload the image and copy the response URL
+    URL=$(curl -X POST \
+      -H "Content-Type: multipart/form-data" \
+      -H "Accept: application/json" \
+      -H "User-Agent: ShareX/13.4.0" \
+      -H "Authorization: $KEY" \
+      -F "file=@$IMAGEPATH$IMAGENAME.png" "https://$DOMAIN/" | grep -Po '(?<="resource":")[^"]+')
+    rm $FILE
+fi
+# Echo instead of printf as echo is marginally faster than printf
+echo -n "$URL" | xclip -sel clip
+

--- a/flameshot_example.sh
+++ b/flameshot_example.sh
@@ -5,20 +5,23 @@ KEY="" # Your ass upload token
 DOMAIN="" # Your upload domain (without http:// or https://)
 
 flameshot config -f "$IMAGENAME" # Make sure that Flameshot names the file correctly
-flameshot gui -r -p "$IMAGEPATH" # Prompt the screenshot GUI
+flameshot gui -r -p "$IMAGEPATH" > /dev/null # Prompt the screenshot GUI, also append the random gibberish to /dev/null
 
 FILE="$IMAGEPATH$IMAGENAME.png" # File path and file name combined
 
 # Check if file exists to handle Curl and rm errors
-if test -f "$FILE"; then
-  # Then upload the image and copy the response URL
-  URL=$(curl -s -o /dev/null -X POST \
-    -H "Content-Type: multipart/form-data" \
-    -H "Accept: application/json" \
-    -H "User-Agent: ShareX/13.4.0" \
-    -H "Authorization: $KEY" \
-    -F "file=@$FILE" "https://$DOMAIN/" | grep -Po '(?<="resource":")[^"]+')
-
-  printf "%s" "$URL" | xclip -sel clip
-  rm "$FILE"
-fi 
+# then upload the image and copy the response URL
+if [ -f "$FILE" ]; then
+    echo "$FILE exists."
+    URL=$(curl -X POST \
+      -H "Content-Type: multipart/form-data" \
+      -H "Accept: application/json" \
+      -H "User-Agent: ShareX/13.4.0" \
+      -H "Authorization: $KEY" \
+      -F "file=@$IMAGEPATH$IMAGENAME.png" "https://$DOMAIN/" | grep -Po '(?<="resource":")[^"]+')
+    # printf instead of echo as echo appends a newline
+    printf "%s" "$URL" | xclip -sel clip
+    rm "$IMAGEPATH$IMAGENAME.png" # Delete the image locally
+else 
+    echo "Aborted."
+fi

--- a/flameshot_example.sh
+++ b/flameshot_example.sh
@@ -12,13 +12,13 @@ FILE="$IMAGEPATH$IMAGENAME.png" # File path and file name combined
 # Check if file exists to handle Curl and rm errors
 if test -f "$FILE"; then
   # Then upload the image and copy the response URL
-  URL=$(curl -X POST \
+  URL=$(curl -s -o /dev/null -X POST \
     -H "Content-Type: multipart/form-data" \
     -H "Accept: application/json" \
     -H "User-Agent: ShareX/13.4.0" \
     -H "Authorization: $KEY" \
     -F "file=@$FILE" "https://$DOMAIN/" | grep -Po '(?<="resource":")[^"]+')
 
-  printf "%s" "$URL" | xclip -sel clip # Uses echo instead of printf as echo is marginally faster than printf
+  printf "%s" "$URL" | xclip -sel clip
   rm "$FILE"
 fi 


### PR DESCRIPTION
## Checklist
<!-- All boxes are required -->

- [x] I have read the [Contributing Guidelines]
- [x] I acknowledge that any submitted code will be licensed under the [ISC License]
- [x] I confirm that submitted code is my own work
- [x] I have tested the code, and confirm that it works

## Enviroment
<!-- Describe your development environment -->

- Operating System: Arch Linux (5.15.13-arch1-1) (i use arch btw)
- Node version: 8.3.0
- npm version: v16.3.1

## Description
<!-- Describe your PR in detail. Include links to any relevant Issues. -->

Two small size "improvements" to handle errors from `Curl` and `rm` if screenshot has been aborted. Basically, those errors will not be thrown *at all* if user aborts the process. Handy.



[Contributing Guidelines]: https://github.com/tycrek/ass/blob/master/CONTRIBUTING.md
[ISC License]: https://github.com/tycrek/ass/blob/master/LICENSE
