### PR TITLE
Remove rootless Docker as it causes issues for some hosts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# ass Dockerfile v0.3.0
+# ass Dockerfile v0.3.1
 # authors:
 #  - tycrek <t@tycrek.com> (https://tycrek.com/)
 #  - Zusier <zusier@pm.me> (https://github.com/Zusier)
@@ -17,12 +17,7 @@ RUN mkdir -p /opt/ass/uploads/thumbnails/ && \
     mkdir -p /opt/ass/share/ && \
     touch /opt/ass/config.json && \
     touch /opt/ass/auth.json && \
-    touch /opt/ass/data.json && \
-    # Set permissions for rootless user
-    chown -R node:node /opt/ass
-
-# Set the user
-USER node
+    touch /opt/ass/data.json
 
 # Install dependencies as rootless user
 RUN npm i --save-dev && \


### PR DESCRIPTION
resolves: #147

## Checklist
<!-- All boxes are required -->

- [x] I have read the [Contributing Guidelines]
- [x] I acknowledge that any submitted code will be licensed under the [ISC License]
- [x] I confirm that submitted code is my own work
- [x] I have tested the code, and confirm that it works

## Enviroment
<!-- Describe your development environment -->

(This was a fresh test server acting as if it were in production)

- Operating System: Ubuntu 22.04
- Node version: N/A (Docker)
- npm version: N/A (Docker)
- Docker version: `20.10.17, build 100c701`
- Compose version: `2.6.0`

## Description
<!-- Describe your PR in detail. Include links to any relevant Issues. -->

This PR removes the usage of the included `node` user. For whatever reason, the container does not retain proper permissions on the Volumes (they remain owned by `root:root`). This will just go back to the previous method where ass ran as `root`.

I ran into the issue referenced in #147, and this fix resolved the issue.

[Contributing Guidelines]: https://github.com/tycrek/ass/blob/master/CONTRIBUTING.md
[ISC License]: https://github.com/tycrek/ass/blob/master/LICENSE
