### PR TITLE
fix: docker install

### DIFF
--- a/install/docker-linux.sh
+++ b/install/docker-linux.sh
@@ -23,9 +23,9 @@ read -n 1 -s -r -p "Press any key to continue..."
 echo Running setup...
 
 # Bring up the container and run the setup
-docker compose up -d && docker compose exec ass npm run setup && docker compose restart
+docker-compose up -d && docker-compose exec ass npm run setup && docker-compose restart
 
 # Done!
 echo "ass-docker for Linux installed!"
 echo "Run the following to view commands:"
-echo "$ docker compose logs -f --tail=50 --no-log-prefix ass"
+echo "$ docker-compose logs -f --tail=50 --no-log-prefix ass"


### PR DESCRIPTION
## Checklist
<!-- All boxes are required -->

- [x] I have read the [Contributing Guidelines]
- [x] I acknowledge that any submitted code will be licensed under the [ISC License]
- [x] I confirm that submitted code is my own work
- [x] I have tested the code, and confirm that it works

## Enviroment
<!-- Describe your development environment -->

- Operating System: Ubuntu 22.04
- Node version: 16.14.0
- npm version: Latest

## Description
<!-- Describe your PR in detail. Include links to any relevant Issues. -->
On Ubuntu, the Linux install fails as the `docker compose` command has been replaced with `docker-compose`.


[Contributing Guidelines]: https://github.com/tycrek/ass/blob/master/CONTRIBUTING.md
[ISC License]: https://github.com/tycrek/ass/blob/master/LICENSE
