### PR TITLE
Fix mismatched theme options

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -290,6 +290,7 @@ If you want to customize the font or colours of the viewer page, create a file i
 | **`bgViewer`** | Background colour for the viewer element |
 | **`txtPrimary`** | Primary text colour; this should be your main brand colour. |
 | **`txtSecondary`** | Secondary text colour; this is used for the file details. |
+| **`linkPrimary`** | Primary link colour |
 | **`linkHover`** | Colour of the `hover` effect for links |
 | **`linkActive`** | Colour of the `active` effect for links |
 | **`borderHover`** | Colour of the `hover` effect for borders; this is used for the underlining links. |

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,10 +18,11 @@ const defaults = {
 	bgViewer: '#151515',
 
 	// Text colours
-	txtPrimary: '#FD842D',
+	txtPrimary: '#BDBDBD',
 	txtSecondary: '#BDBDBD',
 
 	// Links
+	linkPrimary: '#FD842D',
 	linkHover: '#FD710D',
 	linkActive: '#DE5E02',
 

--- a/tailwind.css
+++ b/tailwind.css
@@ -13,7 +13,7 @@
 		@apply no-underline hover_no-underline active_no-underline visited_no-underline
 
 			/* regular, visited */
-			text-primary visited_text-primary
+			text-link visited_text-link
 			border-b-2 visited_border-b-2
 			border-transparent visited_border-transparent
 			rounded-sm visited_rounded-sm

--- a/views/view.pug
+++ b/views/view.pug
@@ -21,10 +21,10 @@ html
 				* { display: none !important; }
 			meta(http-equiv='refresh' content=`0; url='${resourceAttr.src}'`)
 
-	body.font-main.text-secondary.bg-page
+	body.font-main.bg-page
 		.w-full.h-full.flex.justify-center.items-center.text-center
 			.bg-viewer.rounded-24
-				h4.mx-4.mt-6.mb-4.text-3xl.font-main!=title
+				h4.mx-4.mt-6.mb-4.text-3xl.font-main.text-primary!=title
 				figure.block.mx-10.my-4.flex.flex-col.align-items-center
 					if fileIs.video
 						video.res-media(controls loop muted playsinline preload='metadata')&attributes(resourceAttr)
@@ -36,10 +36,10 @@ html
 						code!=mimetype
 					figcaption
 						br
-						span.text-2xl Uploaded by #[strong!=uploader]
+						span.text-2xl.text-primary Uploaded by #[strong!=uploader]
 						br
-						span #{timestamp} (#{size})
+						span.text-secondary #{timestamp} (#{size})
 						br
 						span: a.link(href='#' onclick=`window.location = '${resourceAttr.src}?download=yes'; return false;` download=title) Download
 				if showAd
-					.mx-4.mb-8.text-footer: p Image hosted by #[a.link(href='https://github.com/tycrek/ass' target='_blank'): strong ass], the superior self-hosted ShareX server
+					.mx-4.mb-8.text-footer.text-secondary: p Image hosted by #[a.link(href='https://github.com/tycrek/ass' target='_blank'): strong ass], the superior self-hosted ShareX server


### PR DESCRIPTION
## Checklist

- [x] I have read the [Contributing Guidelines]
- [x] I acknowledge that any submitted code will be licensed under the [ISC License]
- [x] I confirm that submitted code is my own work
- [x] I have tested the code, and confirm that it works

## Environment

- Operating System: Windows 11
- Node version: v18.12.1
- npm version: v8.19.2

## Description

I have fixed the `txtPrimary` and `txtSecondary` classes to be on the correct text in the index view.
Along with this, since the old links used `txtPrimary` I have added a `linkPrimary` class which will represent the base link colour before any other effects take place.

The default ass colour scheme is still in place and works with this PR.

## Recommended

For further additions to this theming, I would suggest adding a txtTertiary class which will represent the `ad` text colour. or the size text colour.
I did not include this though as that is on your discretion to add.