### PR TITLE
Added modifying meta/deleting users via API

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -188,6 +188,58 @@ export const deleteUser = (unid: string): Promise<void> => new Promise((resolve,
 });
 
 /**
+ * Sets a meta value for a user
+ * @since v0.14.1
+ */
+export const setUserMeta = (unid: string, key: string, value: any, force = false): Promise<User> => new Promise((resolve, reject) => {
+
+	// Find the user
+	const user = users.find((user) => user.unid === unid);
+	if (!user) return reject(new Error('User not found'));
+
+	// Set the meta value
+	if (user.meta[key] && !force) return reject(new Error('Meta key already exists'));
+
+	user.meta[key] = value;
+
+	// Save the new user to auth.json
+	const authPath = path('auth.json');
+	const authData = fs.readJsonSync(authPath) as Users;
+	const userIndex = authData.users.findIndex((user) => user.unid === unid);
+	authData.users[userIndex] = user;
+	fs.writeJson(authPath, authData, { spaces: '\t' })
+		.then(() => log.info('Set meta value for', user.unid, `${key}=${value}`))
+		.then(() => resolve(user))
+		.catch(reject);
+});
+
+/**
+ * Deletes a meta value for a user
+ * @since v0.14.1
+ */
+export const deleteUserMeta = (unid: string, key: string): Promise<User> => new Promise((resolve, reject) => {
+
+	// Find the user
+	const user = users.find((user) => user.unid === unid);
+	if (!user) return reject(new Error('User not found'));
+
+	// Delete the meta value
+	if (!user.meta[key]) return reject(new Error('Meta key does not exist'));
+
+	delete user.meta[key];
+
+	// Save the new user to auth.json
+	const authPath = path('auth.json');
+	const authData = fs.readJsonSync(authPath) as Users;
+	const userIndex = authData.users.findIndex((user) => user.unid === unid);
+	authData.users[userIndex] = user;
+	fs.writeJson(authPath, authData, { spaces: '\t' })
+		.then(() => log.info('Deleted meta value for', user.unid, key))
+		.then(() => resolve(user))
+		.catch(reject);
+});
+
+/**
  * Called by ass.ts on startup
  * @since v0.14.0
  */

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -165,6 +165,29 @@ export const setUserPassword = (unid: string, password: string): Promise<User> =
 });
 
 /**
+ * Deletes a user account
+ * @since v0.14.1
+ */
+export const deleteUser = (unid: string): Promise<void> => new Promise((resolve, reject) => {
+
+	// Find the user
+	const user = users.find((user) => user.unid === unid);
+	if (!user) return reject(new Error('User not found'));
+
+	// Remove the user from the users map
+	users.splice(users.indexOf(user), 1);
+
+	// Save the new user to auth.json
+	const authPath = path('auth.json');
+	const authData = fs.readJsonSync(authPath) as Users;
+	const userIndex = authData.users.findIndex((user) => user.unid === unid);
+	authData.users.splice(userIndex, 1);
+	fs.writeJson(authPath, authData, { spaces: '\t' })
+		.then(() => resolve())
+		.catch(reject);
+});
+
+/**
  * Called by ass.ts on startup
  * @since v0.14.0
  */

--- a/src/routers/api.ts
+++ b/src/routers/api.ts
@@ -5,7 +5,7 @@
  */
 
 import { Router, Request, Response, NextFunction } from 'express';
-import { findFromToken, setUserPassword, users, createNewUser, deleteUser, verifyCliKey } from '../auth';
+import { findFromToken, setUserPassword, users, createNewUser, deleteUser, setUserMeta, deleteUserMeta, verifyCliKey } from '../auth';
 import { log } from '../utils';
 import { data } from '../data';
 import { User } from '../types/auth';
@@ -102,11 +102,34 @@ function buildUserRouter() {
 			.catch((err) => errorHandler(res, err));
 	});
 
-	// Update a user
+	// Update a user meta key/value
 	// Admin only
-	userRouter.put('/:id', adminAuthMiddleware, (req: Request, res: Response) => {
+	userRouter.put('/meta/:id', adminAuthMiddleware, (req: Request, res: Response) => {
 		const id = req.params.id;
-		//WIP
+		const key: string | undefined = req.body.key;
+		const value: any = req.body.value;
+		const force = req.body.force ?? false;
+
+		if (key == null || key.length === 0 || value == null || value.length === 0)
+			return res.sendStatus(400);
+
+		setUserMeta(id, key, value, force)
+			.then(() => res.sendStatus(200))
+			.catch((err) => errorHandler(res, err));
+	});
+
+	// Delete a user meta key
+	// Admin only
+	userRouter.delete('/meta/:id', adminAuthMiddleware, (req: Request, res: Response) => {
+		const id = req.params.id;
+		const key: string | undefined = req.body.key;
+
+		if (key == null || key.length === 0)
+			return res.sendStatus(400);
+
+		deleteUserMeta(id, key)
+			.then(() => res.sendStatus(200))
+			.catch((err) => errorHandler(res, err));
 	});
 
 	return userRouter;

--- a/src/routers/api.ts
+++ b/src/routers/api.ts
@@ -21,9 +21,14 @@ const RouterApi = Router();
  */
 const errorHandler = (res: Response, err: Error | any) => {
 	log.error(err);
-	if (err.message === 'User not found')
-		return res.sendStatus(404);
-	res.sendStatus(500);
+	switch (err.message) {
+		case 'User not found':
+			return res.sendStatus(404);
+		case 'Meta key already exists':
+			return res.sendStatus(409);
+		default:
+			return res.sendStatus(500);
+	}
 };
 
 /**

--- a/src/routers/api.ts
+++ b/src/routers/api.ts
@@ -89,6 +89,10 @@ function buildUserRouter() {
 			.catch((err) => errorHandler(res, err));
 	});
 
+	// Get all users
+	// Admin only
+	userRouter.get('/all', adminAuthMiddleware, (req: Request, res: Response) => res.json(users));
+
 	// Get a user (must be last as it's a catch-all)
 	// Admin only
 	userRouter.get('/:id', adminAuthMiddleware, (req: Request, res: Response) =>
@@ -104,7 +108,7 @@ function buildUserRouter() {
 			.catch((err) => errorHandler(res, err));
 	});
 
-	// Update a user meta key/value
+	// Update a user meta key/value (/meta can be after /:id because they are not HTTP GET)
 	// Admin only
 	userRouter.put('/meta/:id', adminAuthMiddleware, (req: Request, res: Response) => {
 		const id = req.params.id;

--- a/src/routers/api.ts
+++ b/src/routers/api.ts
@@ -22,12 +22,9 @@ const RouterApi = Router();
 const errorHandler = (res: Response, err: Error | any) => {
 	log.error(err);
 	switch (err.message) {
-		case 'User not found':
-			return res.sendStatus(404);
-		case 'Meta key already exists':
-			return res.sendStatus(409);
-		default:
-			return res.sendStatus(500);
+		case 'User not found': return res.sendStatus(404);
+		case 'Meta key already exists': return res.sendStatus(409);
+		default: return res.sendStatus(500);
 	}
 };
 


### PR DESCRIPTION
## Checklist
<!-- All boxes are required -->

- [x] I have read the [Contributing Guidelines]
- [x] I acknowledge that any submitted code will be licensed under the [ISC License]
- [x] I confirm that submitted code is my own work
- [x] I have tested the code, and confirm that it works

## Enviroment
<!-- Describe your development environment -->

- Operating System: Win 10
- Node version: 16
- npm version: 8

## Description
<!-- Describe your PR in detail. Include links to any relevant Issues. -->

This will allow developers to modify a users meta key/value pairs via the API. It also introduces the ability to delete users via the API.

To delete users, call `HTTP DELETE /api/user/:id`. ass will return one of `200, 404`, or `500`.

When setting metadata, you must use `HTTP PUT /api/user/meta/:id`. If the key already exists, ass will return `409 Conflict`.

Additionally, I added `HTTP GET /api/user/all` (admin-only) to get a list of all users.

In ALL API routes, `:id` indicates the users `unid` (Unique [Nano ID](https://github.com/ai/nanoid)).

I'll document the routes more in the future. See #133 for more details.

[Contributing Guidelines]: https://github.com/tycrek/ass/blob/master/CONTRIBUTING.md
[ISC License]: https://github.com/tycrek/ass/blob/master/LICENSE
