### PR TITLE
:sparkles: Added /version endpoint to retrieve version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,5 @@ config.json
 
 # share/ directory
 share/
+
+.idea/

--- a/src/routers/api.ts
+++ b/src/routers/api.ts
@@ -191,9 +191,24 @@ function buildResourceRouter() {
 	return resourceRouter;
 }
 
+function buildVersionRouter() {
+	const versionRouter = Router();
+
+
+	versionRouter.get("/", (req: Request, res: Response) => {
+		const project = require('../../package.json');
+		res.type("json").send({
+			version: project.version})
+
+	});
+
+	return versionRouter;
+}
+
 export const onStart = () => {
 	RouterApi.use('/user', buildUserRouter());
 	RouterApi.use('/resource', buildResourceRouter());
+	RouterApi.use('/version', buildVersionRouter());
 
 	return RouterApi;
 };


### PR DESCRIPTION
## Checklist

- [x] I have read the [Contributing Guidelines]
- [x] I acknowledge that any submitted code will be licensed under the [ISC License]
- [x] I confirm that submitted code is my own work
- [x] I have tested the code, and confirm that it works

## Enviroment

- Operating System: macOS
- Node version: 18.12.1
- npm version: 8.19.2

## Description
This pr simply allowes you to retrieve the current version under the following route: /api/version.
It does not change a lot, but it allows to retrieve the version for 3th party applications


[Contributing Guidelines]: https://github.com/tycrek/ass/blob/master/CONTRIBUTING.md
[ISC License]: https://github.com/tycrek/ass/blob/master/LICENSE
